### PR TITLE
add a maximum batch size limit for CPU inference

### DIFF
--- a/inference/pipeline/translate.py
+++ b/inference/pipeline/translate.py
@@ -44,20 +44,24 @@ class Translator(BasePipeline):
                 )
                 duration = time.time() - start_time
 
-                print(f"[{self.config.device}] - Processing batch: {end_index}/{total} - Time: {duration:.2f}s")
+                print(f"[{self.config.device}] Processing batch: {end_index}/{total} - Time: {duration:.2f}s")
 
                 self.save_results(outputs)
                 start_index = end_index
                 self.adjust_batch_size(+1)
 
-            except (RuntimeError, torch.cuda.OutOfMemoryError):
-                print(f"⚠️[{self.config.device}] Out of Memory. Reducing batch size.")
+            except torch.cuda.OutOfMemoryError:
+                print(f"[{self.config.device}] ⚠️ Out of Memory. Reducing batch size.")
                 self.adjust_batch_size(-1)
                 torch.cuda.empty_cache()
                 gc.collect()
 
     def adjust_batch_size(self, delta: int):
-        new_size = max(1, self.batch_size + delta)
+        if self.config.device == 'auto':
+            new_size = max(1, self.batch_size + delta)
+        else:
+            # Limit maximum batch size for CPU inference
+            new_size = min(80, self.batch_size + delta)
         print(f"[{self.config.device}] Batch size {'increased' if delta > 0 else 'decreased'}: {self.batch_size} → {new_size}")
         self.batch_size = new_size
 


### PR DESCRIPTION
 to prevent the process from being killed by the OS