### PR TITLE
Update GHCR token loading and refactor env helpers

### DIFF
--- a/infra/k8s/scripts/common.sh
+++ b/infra/k8s/scripts/common.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Helper to load environment variables from a .env file located one directory
+# above the calling script. The script's directory should be passed as the first
+# argument.
+load_env() {
+  local caller_dir="$1"
+  local env_file="$caller_dir/../.env"
+  if [ -f "$env_file" ]; then
+    set -a
+    source "$env_file"
+    set +a
+  fi
+}

--- a/infra/k8s/scripts/deploy_all.sh
+++ b/infra/k8s/scripts/deploy_all.sh
@@ -4,14 +4,10 @@
 # 스크립트 실행 중 오류 발생시 즉시 중단
 set -e
 
-# Load environment variables if .env exists next to this script
+# Load shared functions and environment variables
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENV_FILE="$SCRIPT_DIR/../.env"
-if [ -f "$ENV_FILE" ]; then
-  set -a
-  source "$ENV_FILE"
-  set +a
-fi
+source "$SCRIPT_DIR/common.sh"
+load_env "$SCRIPT_DIR"
 
 bash ./deploy_minio.sh
 bash ./deploy_spark.sh

--- a/infra/k8s/scripts/deploy_minio.sh
+++ b/infra/k8s/scripts/deploy_minio.sh
@@ -2,14 +2,10 @@
 # 스크립트 실행 중 오류 발생시 즉시 중단
 set -e
 
-# Load environment variables if .env exists next to this script
+# Load shared functions and environment variables
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENV_FILE="$SCRIPT_DIR/../.env"
-if [ -f "$ENV_FILE" ]; then
-  set -a
-  source "$ENV_FILE"
-  set +a
-fi
+source "$SCRIPT_DIR/common.sh"
+load_env "$SCRIPT_DIR"
 
 echo "🚀 minio 배포 시작..."
 

--- a/infra/k8s/scripts/deploy_spark.sh
+++ b/infra/k8s/scripts/deploy_spark.sh
@@ -2,14 +2,10 @@
 # 스크립트 실행 중 오류 발생시 즉시 중단
 set -e
 
-# Load environment variables if .env exists next to this script
+# Load shared functions and environment variables
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENV_FILE="$SCRIPT_DIR/../.env"
-if [ -f "$ENV_FILE" ]; then
-  set -a
-  source "$ENV_FILE"
-  set +a
-fi
+source "$SCRIPT_DIR/common.sh"
+load_env "$SCRIPT_DIR"
 
 echo "🚀 spark-operator 배포 시작..."
 

--- a/scripts/spark/build.sh
+++ b/scripts/spark/build.sh
@@ -2,18 +2,24 @@
 set -e
 
 # Build Spark container images and push to GHCR.
-# Requires an .env file with GHCR credentials in the format:
-# ghcr=<TOKEN>
+# Requires an .env file containing:
+#   GHCR_TOKEN=<TOKEN>
 
-if [ -f .env ]; then
-  GHCR_TOKEN=$(grep '^ghcr=' .env | cut -d '=' -f2-)
+# Resolve .env relative to this script so it works from any directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../../.env"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  source "$ENV_FILE"
+  set +a
 else
-  echo ".env file not found. Please create one with ghcr=<TOKEN> defined."
+  echo ".env file not found. Please create one with GHCR_TOKEN defined."
   exit 1
 fi
 
 if [ -z "$GHCR_TOKEN" ]; then
-  echo "GHCR token not found in .env (expected format: ghcr=...)."
+  echo "GHCR_TOKEN not found in .env."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- update `scripts/spark/build.sh` to source `.env` relative to the script
- add a shared `common.sh` helper and use it in deploy scripts
- remove duplicated env loading logic

## Testing
- `bash -n scripts/spark/build.sh`
- `bash -n infra/k8s/scripts/deploy_all.sh`
- `bash -n infra/k8s/scripts/deploy_minio.sh`
- `bash -n infra/k8s/scripts/deploy_spark.sh`
- `bash -n infra/k8s/scripts/common.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fc11f27d48333835e48561741b366