### PR TITLE
Fix HADOOP_CONF_DIR path

### DIFF
--- a/infra/hadoop/conf/hadoop-env.sh
+++ b/infra/hadoop/conf/hadoop-env.sh
@@ -71,7 +71,7 @@ export HADOOP_HOME="/opt/hadoop-3.4.1"
 # /etc/profile.d or equivalent.  Some options (such as
 # --config) may react strangely otherwise.
 #
-export HADOOP_CONF_DIR="/home/jmhwang/Documents/github/jmhwang-dev/e-commerce/hadoop/conf"
+export HADOOP_CONF_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 
 # The maximum amount of heap to use (Java -Xmx).  If no unit


### PR DESCRIPTION
## Summary
- set `HADOOP_CONF_DIR` using the directory of `hadoop-env.sh`

## Testing
- `grep -R "jmhwang-dev/e-commerce/hadoop/conf" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_683fc6888f2083338e7f1781afe538d5