### PR TITLE
Fix git clone path logic

### DIFF
--- a/infra/ansible/group_vars/all.yml
+++ b/infra/ansible/group_vars/all.yml
@@ -1,6 +1,8 @@
 ---
 ansible_user: jmhwang
-git_clone_path: "{{ ansible_env.HOME }}/Documents/github/jmhwang-dev/e-commerce"
+# Path to the root of this repository. Override when running the playbook from a different
+# location.
+git_clone_path: "{{ playbook_dir | dirname }}"
 
 java_package: openjdk-8-jdk
 jdk_dir_name_pattern: java-8-openjdk*


### PR DESCRIPTION
## Summary
- derive `git_clone_path` from `playbook_dir`
- document how to override the variable

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683fc6ab93708333907425bd94fbe342