### PR TITLE
Ensure dataset loading only happens in main guard

### DIFF
--- a/src/ecommerce/features/product.py
+++ b/src/ecommerce/features/product.py
@@ -3,12 +3,6 @@ from ecommerce.utils.paths import SILVER_DIR
 import pandas as pd
 import os
 
-# Load datasets
-products_df, _ = get_dataset(BronzeDataName.PRODUCTS)
-products_df = products_df.drop_duplicates()
-category_df, _ = get_dataset(BronzeDataName.CATEGORY)
-category_df = category_df.drop_duplicates()
-
 
 def translate_categories(products_df: pd.DataFrame, category_df: pd.DataFrame) -> pd.DataFrame:
     # 1. 고유 카테고리 추출
@@ -55,7 +49,17 @@ def translate_products(products_df: pd.DataFrame, category_mapping_df: pd.DataFr
         index=False
     )
 
-if __name__ == "__main__":
+
+def main() -> None:
+    products_df, _ = get_dataset(BronzeDataName.PRODUCTS)
+    products_df = products_df.drop_duplicates()
+    category_df, _ = get_dataset(BronzeDataName.CATEGORY)
+    category_df = category_df.drop_duplicates()
+
     category_mapping_df = translate_categories(products_df, category_df)
     translate_products(products_df, category_mapping_df)
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- avoid dataset load on import in `product.py`
- add `main()` to handle dataset loading and feature generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyspark', No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68635cfe392c8333bd5bc16819e3eb48