### PR TITLE
Update test docs and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ poetry run python jobs/inference/run_reviews_postprocess.py
 ```bash
 poetry run pytest
 ```
+Spark-related tests require `pyspark` to be installed. Configuration tests rely on
+the `yaml` module provided by the `pyyaml` package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,5 @@ packages = [
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"
 pytest = "^8.4.1"
+pyspark = "^3.5"
 


### PR DESCRIPTION
## Summary
- document missing test dependencies
- install pyspark for dev tests

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pyspark')*

------
https://chatgpt.com/codex/tasks/task_e_6863728952d08333a3c15e00d0231943